### PR TITLE
Correctly set target size for scaled iOS variants

### DIFF
--- a/AppIcon.iconset.Contents.template.json
+++ b/AppIcon.iconset.Contents.template.json
@@ -12,6 +12,11 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
     },
@@ -29,6 +34,11 @@
       "size" : "60x60",
       "idiom" : "iphone",
       "scale" : "2x"
+    },
+    {
+      "size" : "60x60",
+      "idiom" : "iphone",
+      "scale" : "3x"
     },
     {
       "idiom" : "ipad",

--- a/generate.js
+++ b/generate.js
@@ -57,7 +57,9 @@ function generateIconSetIcons(iconSet) {
   return Promise.all(contentsTemplate.images.map(image => {
     const targetName = `${image.idiom}-${image.size}-${image.scale}.png`;
     const targetPath = path.join(iconSet, targetName);
-    return generateIcon("icon.png", targetPath, image.size)
+    const targetScale = parseInt(image.scale.slice(0,1));
+    const targetSize = image.size.split("x").map((p) => { return p*targetScale; }).join("x");
+    return generateIcon("icon.png", targetPath, targetSize)
       .then(() => {
         console.log(`    ${chalk.green('✓')}  Generated ${targetName}`);
         contents.images.push({


### PR DESCRIPTION
`generateIconSetIcons` was not actually applying the scale value to the icon size when generating icons for iOS.
This caused build warnings and blurry icons.
Also added 3x versions
Fixes #6