### PR TITLE
Fix generate not respecting source icon path option

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-import": "^2.2.0",
     "istanbul": "^0.4.5",
     "mocha": "^3.0.2",
-    "node-inspector": "^0.12.8"
+    "node-inspector": "^1.1.1"
   },
   "dependencies": {
     "chalk": "^1.1.3",

--- a/src/android/generate-manifest-icons.js
+++ b/src/android/generate-manifest-icons.js
@@ -5,7 +5,7 @@ const androidManifestIcons = require('./AndroidManifest.icons.json');
 const resizeImage = require('../resize/resize-image');
 
 //  Generate Android Manifest icons given a manifest file.
-module.exports = function generateManifestIcons(manifest) {
+module.exports = function generateManifestIcons(sourceIcon, manifest) {
   //  Create the object we will return.
   const results = {
     icons: [],
@@ -24,7 +24,7 @@ module.exports = function generateManifestIcons(manifest) {
       mkdirp(path.dirname(targetPath), (err) => {
         if (err) return reject(err);
         results.icons.push(icon.path);
-        return resolve(resizeImage('icon.png', targetPath, icon.size));
+        return resolve(resizeImage(sourceIcon, targetPath, icon.size));
       });
     });
   })).then(() => results);

--- a/src/android/generate-manifest-icons.specs.js
+++ b/src/android/generate-manifest-icons.specs.js
@@ -3,6 +3,8 @@ const generateManifestIcons = require('./generate-manifest-icons');
 const deleteIfExists = require('../utils/delete-if-exists');
 const fileExists = require('../utils/file-exists');
 
+const iconSource = 'icon.png';
+
 describe('generate-manifest-icons', () => {
   it('should be able to generate icons for the React Native manifest', () => {
     const files = [
@@ -15,12 +17,13 @@ describe('generate-manifest-icons', () => {
 
     //  Delete all of the files we're expecting to create, then generate them.
     return Promise.all(files.map(f => deleteIfExists(f)))
-      .then(() => {
-        return generateManifestIcons('./test/ReactNativeIconTest/android/app/src/main/AndroidManifest.xml')
-        .then(() => {
-          return Promise.all(files.map((file) => {
-            return fileExists(file).then(exists => expect(exists, `${file} should be generated`).to.equal(true));
-          }));
+      .then(() => (
+        generateManifestIcons(iconSource, './test/ReactNativeIconTest/android/app/src/main/AndroidManifest.xml')
+      ))
+      .then(() => Promise.all(files.map(fileExists)))
+      .then((filesDoExist) => {
+        filesDoExist.forEach((fileExists, index) => {
+          expect(fileExists, `${files[index]} should be generated`).to.equal(true);
         });
       });
   });
@@ -36,12 +39,13 @@ describe('generate-manifest-icons', () => {
 
     //  Delete all of the files we're expecting to create, then generate them.
     return Promise.all(files.map(f => deleteIfExists(f)))
-      .then(() => {
-        return generateManifestIcons('test/CordovaApp/platforms/android/AndroidManifest.xml')
-        .then(() => {
-          return Promise.all(files.map((file) => {
-            return fileExists(file).then(exists => expect(exists, `${file} should be generated`).to.equal(true));
-          }));
+      .then(() => (
+        generateManifestIcons(iconSource, 'test/CordovaApp/platforms/android/AndroidManifest.xml')
+      ))
+      .then(() => Promise.all(files.map(fileExists)))
+      .then((filesDoExist) => {
+        filesDoExist.forEach((fileExists, index) => {
+          expect(fileExists, `${files[index]} should be generated`).to.equal(true);
         });
       });
   });
@@ -57,12 +61,13 @@ describe('generate-manifest-icons', () => {
 
     //  Delete all of the files we're expecting to create, then generate them.
     return Promise.all(files.map(f => deleteIfExists(f)))
-      .then(() => {
-        return generateManifestIcons('test/NativeApp/android/native_app/src/main/AndroidManifest.xml')
-        .then(() => {
-          return Promise.all(files.map((file) => {
-            return fileExists(file).then(exists => expect(exists, `${file} should be generated`).to.equal(true));
-          }));
+      .then(() => (
+        generateManifestIcons(iconSource, 'test/NativeApp/android/native_app/src/main/AndroidManifest.xml')
+      ))
+      .then(() => Promise.all(files.map(fileExists)))
+      .then((filesDoExist) => {
+        filesDoExist.forEach((fileExists, index) => {
+          expect(fileExists, `${files[index]} should be generated`).to.equal(true);
         });
       });
   });

--- a/src/android/generate-manifest-icons.specs.js
+++ b/src/android/generate-manifest-icons.specs.js
@@ -3,7 +3,7 @@ const generateManifestIcons = require('./generate-manifest-icons');
 const deleteIfExists = require('../utils/delete-if-exists');
 const fileExists = require('../utils/file-exists');
 
-const iconSource = 'icon.png';
+const sourceIcon = 'icon.png';
 
 describe('generate-manifest-icons', () => {
   it('should be able to generate icons for the React Native manifest', () => {
@@ -18,7 +18,7 @@ describe('generate-manifest-icons', () => {
     //  Delete all of the files we're expecting to create, then generate them.
     return Promise.all(files.map(f => deleteIfExists(f)))
       .then(() => (
-        generateManifestIcons(iconSource, './test/ReactNativeIconTest/android/app/src/main/AndroidManifest.xml')
+        generateManifestIcons(sourceIcon, './test/ReactNativeIconTest/android/app/src/main/AndroidManifest.xml')
       ))
       .then(() => Promise.all(files.map(fileExists)))
       .then((filesDoExist) => {
@@ -40,7 +40,7 @@ describe('generate-manifest-icons', () => {
     //  Delete all of the files we're expecting to create, then generate them.
     return Promise.all(files.map(f => deleteIfExists(f)))
       .then(() => (
-        generateManifestIcons(iconSource, 'test/CordovaApp/platforms/android/AndroidManifest.xml')
+        generateManifestIcons(sourceIcon, 'test/CordovaApp/platforms/android/AndroidManifest.xml')
       ))
       .then(() => Promise.all(files.map(fileExists)))
       .then((filesDoExist) => {
@@ -62,7 +62,7 @@ describe('generate-manifest-icons', () => {
     //  Delete all of the files we're expecting to create, then generate them.
     return Promise.all(files.map(f => deleteIfExists(f)))
       .then(() => (
-        generateManifestIcons(iconSource, 'test/NativeApp/android/native_app/src/main/AndroidManifest.xml')
+        generateManifestIcons(sourceIcon, 'test/NativeApp/android/native_app/src/main/AndroidManifest.xml')
       ))
       .then(() => Promise.all(files.map(fileExists)))
       .then((filesDoExist) => {

--- a/src/generate.js
+++ b/src/generate.js
@@ -9,7 +9,7 @@ module.exports = function generate(sourceIcon, searchRoot) {
     .then(iconSets => Promise.all(iconSets.map((iconset) => {
       console.log(`Found iOS iconset: ${iconset}...`);
 
-      return generateIconsetIcons(iconset)
+      return generateIconsetIcons(sourceIcon, iconset)
         .then((results) => {
           results.icons.forEach((icon) => {
             console.log(`    ${chalk.green('✓')}  Generated ${icon}`);
@@ -20,7 +20,7 @@ module.exports = function generate(sourceIcon, searchRoot) {
     .then(() => findAndroidManifests(searchRoot))
     .then(manifests => Promise.all(manifests.map((manifest) => {
       console.log(`Found Android Manifest: ${manifest}...`);
-      return generateManifestIcons(manifest).then((results) => {
+      return generateManifestIcons(sourceIcon, manifest).then((results) => {
         results.icons.forEach((icon) => {
           console.log(`    ${chalk.green('✓')}  Generated ${icon}`);
         });

--- a/src/generate.specs.js
+++ b/src/generate.specs.js
@@ -1,10 +1,12 @@
 const expect = require('chai').expect;
 const generate = require('./generate');
 
+const sourceIcon = 'icon.png';
+
 describe('generate', () => {
   it('should be able to generate React Native icons', () => {
     //  Delete all of the files we're expecting to create, then generate them.
-    return generate('icon.png', './test/ReactNativeIconTest').then((results) => {
+    return generate(sourceIcon, './test/ReactNativeIconTest').then((results) => {
       //  TODO: Check we found the manifests etc etc
       expect(results).not.to.equal(null);
     });

--- a/src/ios/generate-iconset-icons.js
+++ b/src/ios/generate-iconset-icons.js
@@ -5,7 +5,7 @@ const resizeImage = require('../resize/resize-image');
 const contentsTemplate = require('./AppIcon.iconset.Contents.template.json');
 
 //  Generate xCode icons given an iconset folder.
-module.exports = function generateIconSetIcons(iconset) {
+module.exports = function generateIconSetIcons(sourceIcon, iconset) {
   return new Promise((resolve, reject) => {
     //  Build the results object.
     const results = {
@@ -24,7 +24,7 @@ module.exports = function generateIconSetIcons(iconset) {
       const targetPath = path.join(iconset, targetName);
       const targetScale = parseInt(image.scale.slice(0, 1), 10);
       const targetSize = image.size.split('x').map(p => p * targetScale).join('x');
-      return resizeImage('icon.png', targetPath, targetSize)
+      return resizeImage(sourceIcon, targetPath, targetSize)
         .then(() => {
           results.icons.push(targetName);
           contents.images.push({

--- a/src/ios/generate-iconset-icons.specs.js
+++ b/src/ios/generate-iconset-icons.specs.js
@@ -3,6 +3,8 @@ const generateIconsetIcons = require('./generate-iconset-icons');
 const deleteIfExists = require('../utils/delete-if-exists');
 const fileExists = require('../utils/file-exists');
 
+const iconSource = 'icon.png';
+
 describe('generate-iconset-icons', () => {
   it('should be able to generate icons for the React Native iconset', () => {
     const files = [
@@ -25,13 +27,14 @@ describe('generate-iconset-icons', () => {
     ];
 
     //  Delete all of the files we're expecting to create, then generate them.
-    return Promise.all(files.map(f => deleteIfExists(f)))
-      .then(() => {
-        return generateIconsetIcons('test/ReactNativeIconTest/ios/ReactNativeIconTest/Images.xcassets/AppIcon.appiconset')
-        .then(() => {
-          return Promise.all(files.map((file) => {
-            return fileExists(file).then(exists => expect(exists, `${file} should be generated`).to.equal(true));
-          }));
+    return Promise.all(files.map(deleteIfExists))
+      .then(() => (
+        generateIconsetIcons(iconSource, 'test/ReactNativeIconTest/ios/ReactNativeIconTest/Images.xcassets/AppIcon.appiconset')
+      ))
+      .then(() => Promise.all(files.map(fileExists)))
+      .then((filesDoExist) => {
+        filesDoExist.forEach((fileExists, index) => {
+          expect(fileExists, `${files[index]} should be generated`).to.equal(true);
         });
       });
   });
@@ -57,13 +60,14 @@ describe('generate-iconset-icons', () => {
     ];
 
     //  Delete all of the files we're expecting to create, then generate them.
-    return Promise.all(files.map(f => deleteIfExists(f)))
-      .then(() => {
-        return generateIconsetIcons('test/CordovaApp/platforms/ios/ionic_app/Images.xcassets/AppIcon.appiconset')
-        .then(() => {
-          return Promise.all(files.map((file) => {
-            return fileExists(file).then(exists => expect(exists, `${file} should be generated`).to.equal(true));
-          }));
+    return Promise.all(files.map(deleteIfExists))
+      .then(() => (
+        generateIconsetIcons(iconSource, 'test/CordovaApp/platforms/ios/ionic_app/Images.xcassets/AppIcon.appiconset')
+      ))
+      .then(() => Promise.all(files.map(fileExists)))
+      .then((filesDoExist) => {
+        filesDoExist.forEach((fileExists, index) => {
+          expect(fileExists, `${files[index]} should be generated`).to.equal(true);
         });
       });
   });
@@ -89,13 +93,14 @@ describe('generate-iconset-icons', () => {
     ];
 
     //  Delete all of the files we're expecting to create, then generate them.
-    return Promise.all(files.map(f => deleteIfExists(f)))
-      .then(() => {
-        return generateIconsetIcons('test/NativeApp/ios/native_app/Assets.xcassets/AppIcon.appiconset')
-        .then(() => {
-          return Promise.all(files.map((file) => {
-            return fileExists(file).then(exists => expect(exists, `${file} should be generated`).to.equal(true));
-          }));
+    return Promise.all(files.map(deleteIfExists))
+      .then(() => (
+        generateIconsetIcons(iconSource, 'test/NativeApp/ios/native_app/Assets.xcassets/AppIcon.appiconset')
+      ))
+      .then(() => Promise.all(files.map(fileExists)))
+      .then((filesDoExist) => {
+        filesDoExist.forEach((fileExists, index) => {
+          expect(fileExists, `${files[index]} should be generated`).to.equal(true);
         });
       });
   });

--- a/src/ios/generate-iconset-icons.specs.js
+++ b/src/ios/generate-iconset-icons.specs.js
@@ -3,7 +3,7 @@ const generateIconsetIcons = require('./generate-iconset-icons');
 const deleteIfExists = require('../utils/delete-if-exists');
 const fileExists = require('../utils/file-exists');
 
-const iconSource = 'icon.png';
+const sourceIcon = 'icon.png';
 
 describe('generate-iconset-icons', () => {
   it('should be able to generate icons for the React Native iconset', () => {
@@ -29,7 +29,7 @@ describe('generate-iconset-icons', () => {
     //  Delete all of the files we're expecting to create, then generate them.
     return Promise.all(files.map(deleteIfExists))
       .then(() => (
-        generateIconsetIcons(iconSource, 'test/ReactNativeIconTest/ios/ReactNativeIconTest/Images.xcassets/AppIcon.appiconset')
+        generateIconsetIcons(sourceIcon, 'test/ReactNativeIconTest/ios/ReactNativeIconTest/Images.xcassets/AppIcon.appiconset')
       ))
       .then(() => Promise.all(files.map(fileExists)))
       .then((filesDoExist) => {
@@ -62,7 +62,7 @@ describe('generate-iconset-icons', () => {
     //  Delete all of the files we're expecting to create, then generate them.
     return Promise.all(files.map(deleteIfExists))
       .then(() => (
-        generateIconsetIcons(iconSource, 'test/CordovaApp/platforms/ios/ionic_app/Images.xcassets/AppIcon.appiconset')
+        generateIconsetIcons(sourceIcon, 'test/CordovaApp/platforms/ios/ionic_app/Images.xcassets/AppIcon.appiconset')
       ))
       .then(() => Promise.all(files.map(fileExists)))
       .then((filesDoExist) => {
@@ -95,7 +95,7 @@ describe('generate-iconset-icons', () => {
     //  Delete all of the files we're expecting to create, then generate them.
     return Promise.all(files.map(deleteIfExists))
       .then(() => (
-        generateIconsetIcons(iconSource, 'test/NativeApp/ios/native_app/Assets.xcassets/AppIcon.appiconset')
+        generateIconsetIcons(sourceIcon, 'test/NativeApp/ios/native_app/Assets.xcassets/AppIcon.appiconset')
       ))
       .then(() => Promise.all(files.map(fileExists)))
       .then((filesDoExist) => {


### PR DESCRIPTION
Firstly, thanks for the awesome project as it saves me a lot of headache managing app icons in react-native! :tada:

Getting into the problem, the current implementation of `generate` does not respect the supplied icon source path given by the `-i` CLI option.

The `generate` function in `src/generate.js` receives the icon path, the problem is that the icon is not passed on to `generateManifestIcons` and `generateIconsetIcons` functions and the string `'icon.png'` was hard-coded. This PR fixes this problem by passing the `sourceIcon` into these 2 functions.

Also I had to bump `node-inspector` to the current latest to avoid npm install problems. If this dep is not used, probably a good idea to remove it as well?

Lastly I also slightly refactored tests for `generateIncosetIcons` and `generateManifestIcons` so that the Promise chain has less nesting and more 'flat'.