### PR TITLE
Fix option --icon for command "generate"

### DIFF
--- a/bin/app-icon.js
+++ b/bin/app-icon.js
@@ -38,11 +38,11 @@ program
       })
       .then((exists) => {
         if (!exists) {
-          console.error(`Source file '${icon}' does not exist. Add the file or specify source icon with the '--icon' paramter.`);
+          console.error(`Source file '${icon}' does not exist. Add the file or specify source icon with the '--icon' parameter.`);
           return process.exit(1);
         }
         //  Generate some icons.
-        return generate({ icon, search, platforms });
+        return generate({ sourceIcon: icon, search, platforms });
       })
       .catch((generateErr) => {
         console.error(chalk.red(`An error occurred generating the icons: ${generateErr.message}`));


### PR DESCRIPTION
The function `generate` takes a `sourceIcon` as option, the CLI was passing `icon`.