### PR TITLE
added ios 1024x1024 marketing icon required by ios 11

### DIFF
--- a/src/ios/AppIcon.iconset.Contents.template.json
+++ b/src/ios/AppIcon.iconset.Contents.template.json
@@ -119,6 +119,12 @@
       "idiom": "ipad",
       "size": "83.5x83.5",
       "scale": "2x"
+    },
+    {
+      "size" : "1024x1024",
+      "idiom" : "ios-marketing",
+      "filename" : "ItunesArtwork@2x.png",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/src/ios/generate-iconset-icons.specs.js
+++ b/src/ios/generate-iconset-icons.specs.js
@@ -24,6 +24,7 @@ describe('generate-iconset-icons', () => {
       'test/ReactNativeIconTest/ios/ReactNativeIconTest/Images.xcassets/AppIcon.appiconset/ipad-72x72-2x.png',
       'test/ReactNativeIconTest/ios/ReactNativeIconTest/Images.xcassets/AppIcon.appiconset/ipad-76x76-1x.png',
       'test/ReactNativeIconTest/ios/ReactNativeIconTest/Images.xcassets/AppIcon.appiconset/ipad-76x76-2x.png',
+      'test/ReactNativeIconTest/ios/ReactNativeIconTest/Images.xcassets/AppIcon.appiconset/ios-marketing-1024x1024-1x.png',
     ];
 
     //  Delete all of the files we're expecting to create, then generate them.
@@ -57,6 +58,7 @@ describe('generate-iconset-icons', () => {
       'test/CordovaApp/platforms/ios/ionic_app/Images.xcassets/AppIcon.appiconset/ipad-72x72-2x.png',
       'test/CordovaApp/platforms/ios/ionic_app/Images.xcassets/AppIcon.appiconset/ipad-76x76-1x.png',
       'test/CordovaApp/platforms/ios/ionic_app/Images.xcassets/AppIcon.appiconset/ipad-76x76-2x.png',
+      'test/CordovaApp/platforms/ios/ionic_app/Images.xcassets/AppIcon.appiconset/ios-marketing-1024x1024-1x.png',
     ];
 
     //  Delete all of the files we're expecting to create, then generate them.
@@ -90,6 +92,7 @@ describe('generate-iconset-icons', () => {
       'test/NativeApp/ios/native_app/Assets.xcassets/AppIcon.appiconset/ipad-72x72-2x.png',
       'test/NativeApp/ios/native_app/Assets.xcassets/AppIcon.appiconset/ipad-76x76-1x.png',
       'test/NativeApp/ios/native_app/Assets.xcassets/AppIcon.appiconset/ipad-76x76-2x.png',
+      'test/NativeApp/ios/native_app/Assets.xcassets/AppIcon.appiconset/ios-marketing-1024x1024-1x.png',
     ];
 
     //  Delete all of the files we're expecting to create, then generate them.


### PR DESCRIPTION
After Apple released Xcode 9, they will require 1024x1024 marketing icon in app icon set. Otherwise, you get a warning, and the app will be rejected. This PR adds proper icon.

More info: https://stackoverflow.com/a/44691659