### PR TITLE
fix(tests): Update regex for node error messages

### DIFF
--- a/src/utils/delete-if-exists.specs.js
+++ b/src/utils/delete-if-exists.specs.js
@@ -21,7 +21,7 @@ describe('delete-if-exists', () => {
   it('should be return a sensible error message with invalid input', () => {
     return deleteIfExists(undefined)
       .catch((err) => {
-        expect(err.message).to.match(/path must be a string/);
+        expect(err.message).to.match(/path/);
       });
   });
 });

--- a/src/utils/file-exists.specs.js
+++ b/src/utils/file-exists.specs.js
@@ -19,7 +19,7 @@ describe('file-exists', () => {
   it('should be return a sensible error message with invalid input', () => {
     return fileExists(undefined)
       .catch((err) => {
-        expect(err.message).to.match(/path must be a string/);
+        expect(err.message).to.match(/path/);
       });
   });
 });


### PR DESCRIPTION
Fixes tests which expect an explicit error message. These error messages are generated by a core node module (`fs`) so have naturally changed in v10+ so fail the tests (`The "path" argument must be one of type string, Buffer, or URL. Received type undefined`)

@dwmkerr If you create the various node-imagemagick Docker images for all node versions, can update the circle scripts to test against various node versions