### PR TITLE
feat(android): improved handling of 'build' folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Icon management for Mobile Apps. Create icons, generate all required sizes, labe
     * [Commit Messages](#commit-messages)
     * [Creating a Release](#creating-a-release)
     * [Builds](#builds)
+    * [Debugging](#debugging)
 * [The Sample Projects](#the-sample-projects)
     * [React Native](#react-native)
     * [Cordova](#cordova)
@@ -240,6 +241,14 @@ make circleci
 ```
 
 The builds use custom docker images which contain the appropriate Node.js runtime, as well as the ImageMagick binaries. These custom images are stored in the `.circleci/images` folder. You can use the `.circleci/images/makefile` makefile to build them, but permissions to push to the `dwmkerr` Docker Hub account are required to publish these images. In general, these should not need to be modified.
+
+### Debugging
+
+The [`debug`](https://www.npmjs.com/package/debug) package is used to support low-level debugging. If you want to see debug messages when running the tool, just set the `DEBUG` environment variable to `app-icon`:
+
+```sh
+DEBUG=app-icon app-icon generate --platforms android
+```
 
 ## The Sample Projects
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -755,10 +755,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
-      "dev": true,
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
@@ -3457,7 +3456,7 @@
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "requires": {
         "glob": "^7.1.3"
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "commander": "^2.19.0",
+    "debug": "^4.1.1",
     "imagemagick-cli": "^0.5.0",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.3"

--- a/src/android/find-android-manifests.js
+++ b/src/android/find-android-manifests.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const debug = require('debug')('app-icon');
 const find = require('../utils/find');
 
 //  Create a regexp to exclude node modules and build intermediates. The build folder rex
@@ -8,12 +9,34 @@ const rexBuildFolder = new RegExp(`${path.normalize('/build/').replace(/\\/g, '\
 
 //  Given a search root, finds all Android manifests.
 module.exports = async function findAndroidManifests(searchRoot) {
+  debug(`searching ${searchRoot} for android manifests`);
+  const absoluteSearchRoot = path.resolve(searchRoot);
   return find(searchRoot, (file, stat) => {
-    //  Exclude: node modules and android build intermediates.
-    if (file.match(rexNodeModules)) return false;
-    if (file.match(rexBuildFolder)) return false;
+    //  Anything which is a directory or does not end with 'AndroidManifest.xml'
+    //  we can immediately ignore.
+    if (!file.match(/AndroidManifest.xml/) || stat.isDirectory()) {
+      //  No point debugging this, we'll just blat the screen with too much output.
+      return false;
+    }
 
-    //  Only grab the manifest file...
-    return file.match(/AndroidManifest.xml/) && !stat.isDirectory();
+    //  Exclude files which look like they might be in node_modules...
+    if (file.match(rexNodeModules)) {
+      debug(`skipping '${file}' as it appears to be in a node_modules folder...`);
+      return false;
+    }
+
+    //  When checking to see if a file is in the 'build' folder, we only want
+    //  to check the _relative_ path - it is OK if the search root or parent
+    //  path includes 'build'.
+    const relativeFilePath = path.relative(absoluteSearchRoot, file);
+
+    //  Exclude files which look like they might be in android build intermediate
+    //  folders...
+    if (relativeFilePath.match(rexBuildFolder)) {
+      debug(`skipping '${file}' as it appears to be in an android build folder...`);
+      return false;
+    }
+
+    return true;
   });
 };


### PR DESCRIPTION
If your project has folder named 'build' as part of its path, manifests
will still be correctly found. Any _subfolders_ which are named 'build'
will still be excluded.

Fixes #109.