### PR TITLE
Android: exclude CordovaLib from found Manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ src/label/test-images/*-output.png
 src/resize/test-images/*output.png
 .nyc_output/
 
+.idea
+*.iml
+
 # Windows junk.
 Thumbs.db

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "scripts": {
     "start": "./bin/app-icon.js",
-    "test": "mocha -t 15000 ./src/{,**/}*.specs.js",
+    "test": "mocha --timeout 20000 ./src/{,**/}*.specs.js",
     "test:debug": "mocha -d -w ./src/{,**/}*.specs.js",
-    "cov": "nyc mocha --timeout 15000 ./src/{,**/}*.specs.js",
+    "cov": "nyc mocha --timeout 20000 ./src/{,**/}*.specs.js",
     "lint": "eslint .",
     "release": "standard-version"
   },
@@ -22,7 +22,9 @@
     "url": "git+https://github.com/dwmkerr/app-icon.git"
   },
   "keywords": [
-    "cordvoa",
+    "android",
+    "ios",
+    "cordova",
     "react-native",
     "icon",
     "cordova-icon",

--- a/src/android/find-android-manifests.js
+++ b/src/android/find-android-manifests.js
@@ -2,9 +2,10 @@ const path = require('path');
 const debug = require('debug')('app-icon');
 const find = require('../utils/find');
 
-//  Create a regexp to exclude node modules and build intermediates. The build folder rex
-//  also needs to be able to handle windows paths.
+//  Create a regexp to exclude node modules, CordovaLib and build intermediates.
+//  The build folder rex also needs to be able to handle windows paths.
 const rexNodeModules = new RegExp('node_modules');
+const rexCordovaLib = new RegExp('CordovaLib');
 const rexBuildFolder = new RegExp(`${path.normalize('/build/').replace(/\\/g, '\\\\')}`);
 
 //  Given a search root, finds all Android manifests.
@@ -22,6 +23,12 @@ module.exports = async function findAndroidManifests(searchRoot) {
     //  Exclude files which look like they might be in node_modules...
     if (file.match(rexNodeModules)) {
       debug(`skipping '${file}' as it appears to be in a node_modules folder...`);
+      return false;
+    }
+
+    //  Exclude files which look like they might be in CordovaLib...
+    if (file.match(rexCordovaLib)) {
+      debug(`skipping '${file}' as it appears to be in a CordovaLib folder...`);
       return false;
     }
 

--- a/src/android/find-android-manifests.specs.js
+++ b/src/android/find-android-manifests.specs.js
@@ -14,11 +14,11 @@ describe('find-android-manifests', () => {
     expect(manifests).to.include(path.normalize('test/ReactNativeIconTest/android/app/src/main/AndroidManifest.xml'));
   });
 
-  it('should be able to find the Cordova manifests', async () => {
+  it('should be able to find the Cordova manifest', async () => {
     const manifests = await findAndroidManifests('./test/CordovaApp');
-    expect(manifests.length).to.equal(2);
+    expect(manifests.length).to.equal(1);
     expect(manifests).to.include(path.normalize('test/CordovaApp/platforms/android/AndroidManifest.xml'));
-    expect(manifests).to.include(path.normalize('test/CordovaApp/platforms/android/CordovaLib/AndroidManifest.xml'));
+    expect(manifests).to.not.include(path.normalize('test/CordovaApp/platforms/android/CordovaLib/AndroidManifest.xml'));
   });
 
   it('should be able to find the Native manifest', async () => {

--- a/src/generate.specs.js
+++ b/src/generate.specs.js
@@ -11,9 +11,9 @@ describe('generate', () => {
     //  Delete all of the files we're expecting to create, then generate them.
     const results = await generate(parameters);
     //  TODO: Check we found the manifests etc etc
-    expect(results).not.to.equal(null);
+    expect(results).to.not.equal(null);
     expect(results.iconsets.length).to.equal(3);
-    expect(results.manifests.length).to.equal(4);
+    expect(results.manifests.length).to.equal(3);
   });
 
   it('should be able to generate test app icons with adaptive icons included', async () => {
@@ -28,9 +28,9 @@ describe('generate', () => {
     //  Delete all of the files we're expecting to create, then generate them.
     const results = await generate(parameters);
     //  TODO: Check we found the manifests etc etc
-    expect(results).not.to.equal(null);
+    expect(results).to.not.equal(null);
     expect(results.iconsets.length).to.equal(3);
-    expect(results.manifests.length).to.equal(4);
-    expect(results.adaptiveIconManifests.length).to.equal(4);
+    expect(results.manifests.length).to.equal(3);
+    expect(results.adaptiveIconManifests.length).to.equal(3);
   });
 });


### PR DESCRIPTION
Resolves #139

Add regex for _CordovaLib/_ to be excluded from `findAndroidManifests()` results.