### PR TITLE
circleci: add node14 image for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,10 @@ jobs:
     <<: *test-common
     docker:
       - image: dwmkerr/node:12-imagemagick
+  test-node14:
+    <<: *test-common
+    docker:
+      - image: dwmkerr/node:14-imagemagick
 
 workflows:
   version: 2
@@ -45,6 +49,11 @@ workflows:
             tags:
               only: /.*/
       - test-node12:
+          # All branches, all tags.
+          filters:
+            tags:
+              only: /.*/
+      - test-node14:
           # All branches, all tags.
           filters:
             tags:

--- a/.circleci/images/makefile
+++ b/.circleci/images/makefile
@@ -2,8 +2,10 @@ build:
 	docker build -t dwmkerr/node:8-imagemagick ./node8/.
 	docker build -t dwmkerr/node:10-imagemagick ./node10/.
 	docker build -t dwmkerr/node:12-imagemagick ./node12/.
+	docker build -t dwmkerr/node:14-imagemagick ./node14/.
 
 push:
 	docker push dwmkerr/node:8-imagemagick
 	docker push dwmkerr/node:10-imagemagick
 	docker push dwmkerr/node:12-imagemagick
+	docker push dwmkerr/node:14-imagemagick

--- a/.circleci/images/node14/Dockerfile
+++ b/.circleci/images/node14/Dockerfile
@@ -1,0 +1,15 @@
+FROM circleci/node:14
+
+# Install IM and the CAB extract util to unpack windows fonts.
+RUN sudo apt-get update -y \
+    && sudo apt-get install -y curl tar file xz-utils build-essential \
+    cabextract \
+    imagemagick
+
+# Unpack fonts. Needed as ImageMagick uses a default font (Arial) if we do
+# not explicitly specify one.
+RUN cd ~; wget -c https://www.freedesktop.org/software/fontconfig/webfonts/webfonts.tar.gz -O - | tar -xz
+RUN cd ~; cabextract ~/msfonts/*.exe
+RUN mkdir -p ~/.local/share/fonts
+RUN cd ~; cp *.ttf *.TTF ~/.local/share/fonts
+


### PR DESCRIPTION
Given NodeJS 14 is the new LTS.